### PR TITLE
INFRA-2595: added ssl value from state beacause provider response null

### DIFF
--- a/internal/provider/l7resource_resource.go
+++ b/internal/provider/l7resource_resource.go
@@ -396,7 +396,8 @@ func (r *l7resourceResource) Read(ctx context.Context, req resource.ReadRequest,
 		origins = append(origins, flatternL7OriginModel(&originResponse.Data.Result))
 	}
 
-	state = flatternL7ResourceModel(resourceResponse.Data.Result)
+	results := hackSPSSLState(state, resourceResponse)
+	state = flatternL7ResourceModel(results.Data.Result)
 	state.Origins = origins
 
 	// Set refreshed state


### PR DESCRIPTION
выяснил, что ошибка связанна с тем что в функции read получает данные от провайдера и сохраняет в state, но поскольку провайдер возвращает пустое поле, то терраформ сохраняет в state это значение пустым. Отсюда и постоянное change т к в плане ssl указан а в стейте он сохраняется только до очередного refresh и так по новой в цикле. 
Решением оказался костыль, который перед сохранением в state возьмет данные из кеша стейта и сохранить значение после refresh